### PR TITLE
Fix org-clock-mode

### DIFF
--- a/lambda-line.el
+++ b/lambda-line.el
@@ -222,10 +222,6 @@ Time info is only shown `display-time-mode' is non-nil"
                             :on-deactivate lambda-line-prog-deactivate)
     (mu4e-dashboard-mode    :mode-p lambda-line-mu4e-dashboard-mode-p
                             :format lambda-line-mu4e-dashboard-mode)
-    (fundamental-mode       :mode-p lambda-line-fundamental-mode-p
-                            :format lambda-line-fundamental-mode)
-    (text-mode              :mode-p lambda-line-text-mode-p
-                            :format lambda-line-text-mode)
     (messages-mode          :mode-p lambda-line-messages-mode-p
                             :format lambda-line-messages-mode)
     (message-mode           :mode-p lambda-line-message-mode-p
@@ -288,6 +284,10 @@ Time info is only shown `display-time-mode' is non-nil"
                             :on-deactivate lambda-line-org-clock-deactivate)
     (pdf-view-mode          :mode-p lambda-line-pdf-view-mode-p
                             :format lambda-line-pdf-view-mode)
+    (fundamental-mode       :mode-p lambda-line-fundamental-mode-p
+                            :format lambda-line-fundamental-mode)
+    (text-mode              :mode-p lambda-line-text-mode-p
+                            :format lambda-line-text-mode)
 
     ;; hooks only go last
     (ein-notebook-mode      :on-activate lambda-line-ein-notebook-activate

--- a/lambda-line.el
+++ b/lambda-line.el
@@ -1319,6 +1319,7 @@ STATUS, NAME, PRIMARY, and SECONDARY are always displayed. TERTIARY is displayed
                                  (when branch
                                    branch)
                                  lambda-line-display-group-end)
+			 ""
                          (concat
                           ;; Narrowed buffer
                           (when (buffer-narrowed-p)


### PR DESCRIPTION
These changes fix some issue that exist for org-clock-mode:

1. Because of the order of modes in `lambda-line-mode-formats`, `text-mode` is preferred over `org-clock-mode`. This prevents `org-clock-mode` from ever being used
2. When calling `lambda-line-org-clock-mode`, there is a malformed call to `lambda-line-compose` (missing an argument). I just added an empty string for the `tertiary` argument