### PR TITLE
fix: ensure nil TERTIARY argument is accounted for

### DIFF
--- a/lambda-line.el
+++ b/lambda-line.el
@@ -1121,8 +1121,8 @@ STATUS, NAME, PRIMARY, and SECONDARY are always displayed. TERTIARY is displayed
 
            (propertize primary 'face face-primary)))
 
-          (tertiary (if (not (string-empty-p tertiary)) 
-                       tertiary 
+          (tertiary (if (and tertiary (not (string-empty-p tertiary)))
+                       tertiary
                      (if lambda-line-default-tertiary-function
                          (funcall lambda-line-default-tertiary-function)
                        "")))


### PR DESCRIPTION
When evaluating `lambda-line-term-mode` the TERTIARY arg is nil resulting in an error:

```
  Debugger entered--Lisp error: (wrong-type-argument stringp nil)
    lambda-line-compose(" >_ " "Terminal" "(zsh)" nil "~/")
    lambda-line-term-mode()
    eval((lambda-line-term-mode) t)
    #f(compiled-function () #<bytecode 0x13aedda57dd23f52>)()
    #f(compiled-function () #<bytecode -0x5db3e1955cb81d1>)()
    eval-expression((lambda-line-term-mode) nil nil 127)
    funcall-interactively(eval-expression (lambda-line-term-mode) nil nil 127)
    command-execute(eval-expression record)
    execute-extended-command(nil "eval-expression" nil)
    funcall-interactively(execute-extended-command nil "eval-expression" nil)
    command-execute(execute-extended-command)
```

Perhaps non-intuitively, `string-empty-p` returns `nil` when its argument is `nil`.  This leads to a situation where `concat` is evaluated with a nil argument.